### PR TITLE
Task/2 Fix state machine to avoid unintended transitions

### DIFF
--- a/kaizen-openapi-normalizer/src/main/java/com/reprezen/kaizen/normalizer/v2/V2StateMachine.java
+++ b/kaizen-openapi-normalizer/src/main/java/com/reprezen/kaizen/normalizer/v2/V2StateMachine.java
@@ -24,10 +24,10 @@ public class V2StateMachine extends StateMachine<V2State> {
 		// Set up all state transitions to use while traversing a Swagger model spec
 
 		// ways to get to object definitions
-		transit().from(MODEL).via("paths", "*").to(PATH);
-		transit().from(MODEL).via("definitions", "*").to(SCHEMA_DEF);
-		transit().from(MODEL).via("responses", "*").to(RESPONSE_DEF);
-		transit().from(MODEL).via("parameters", "*").to(PARAMETER_DEF);
+		transit().from(MODEL).via("paths", "re: /.*").to(PATH);
+		transit().from(MODEL).via("definitions", "re: (?!x-)[a-zA-Z0-9._-]+").to(SCHEMA_DEF);
+		transit().from(MODEL).via("responses", "re: (?!x-)[a-zA-Z0-9._-]+").to(RESPONSE_DEF);
+		transit().from(MODEL).via("parameters", "re: (?!x-)[a-zA-Z0-9._-]+").to(PARAMETER_DEF);
 
 		// ways to get to a schema object
 		transit().from(PARAMETER).via("schema").to(SCHEMA); // valid if `in == "body"`

--- a/kaizen-openapi-normalizer/src/main/java/com/reprezen/kaizen/normalizer/v3/V3StateMachine.java
+++ b/kaizen-openapi-normalizer/src/main/java/com/reprezen/kaizen/normalizer/v3/V3StateMachine.java
@@ -36,16 +36,16 @@ public class V3StateMachine extends StateMachine<V3State> {
 		// Set up all state transitions to use while traversing OpenAPI v3 model spec
 
 		// ways to get to component definitions
-		transit().from(MODEL).via("paths", "*").to(PATH);
-		transit().from(MODEL).via("components", "schemas", "*").to(SCHEMA_DEF);
-		transit().from(MODEL).via("components", "responses", "*").to(RESPONSE_DEF);
-		transit().from(MODEL).via("components", "parameters", "*").to(PARAMETER_DEF);
-		transit().from(MODEL).via("components", "examples", "*").to(EXAMPLE_DEF);
-		transit().from(MODEL).via("components", "requestBodies", "*").to(REQUEST_BODY_DEF);
-		transit().from(MODEL).via("components", "headers", "*").to(HEADER_DEF);
-		transit().from(MODEL).via("components", "securitySchemes", "*").to(SECURITY_SCHEME_DEF);
-		transit().from(MODEL).via("components", "links", "*").to(LINK_DEF);
-		transit().from(MODEL).via("components", "callbacks", "*").to(CALLBACK_DEF);
+		transit().from(MODEL).via("paths", "re: /.*").to(PATH);
+		transit().from(MODEL).via("components", "schemas", "re: (?!x-)[A-Za-z0-9._-]+").to(SCHEMA_DEF);
+		transit().from(MODEL).via("components", "responses", "re: (?!x-)[A-Za-z0-9._-]+").to(RESPONSE_DEF);
+		transit().from(MODEL).via("components", "parameters", "re: (?!x-)[A-Za-z0-9._-]+").to(PARAMETER_DEF);
+		transit().from(MODEL).via("components", "examples", "re: (?!x-)[A-Za-z0-9._-]+").to(EXAMPLE_DEF);
+		transit().from(MODEL).via("components", "requestBodies", "re: (?!x-)[A-Za-z0-9._-]+").to(REQUEST_BODY_DEF);
+		transit().from(MODEL).via("components", "headers", "re: (?!x-)[A-Za-z0-9._-]+").to(HEADER_DEF);
+		transit().from(MODEL).via("components", "securitySchemes", "re: (?!x-)[A-Za-z0-9._-]+").to(SECURITY_SCHEME_DEF);
+		transit().from(MODEL).via("components", "links", "re: (?!x-)[A-Za-z0-9._-]+").to(LINK_DEF);
+		transit().from(MODEL).via("components", "callbacks", "re: (?!x-)[A-Za-z0-9._-]+").to(CALLBACK_DEF);
 
 		// ways to get to a schema object
 		transit().from(PARAMETER).via("schema").to(SCHEMA);

--- a/kaizen-openapi-normalizer/src/test/java/com/reprezen/kaizen/normalizer/test/StateMachineTest.java
+++ b/kaizen-openapi-normalizer/src/test/java/com/reprezen/kaizen/normalizer/test/StateMachineTest.java
@@ -27,14 +27,15 @@ public class StateMachineTest extends Assert {
 
 	private void defineTransits() {
 		//         ⇗ "shortcut"⇒ ⇒ ⇒ ⇒ ⇘
-		// Ⓐ ⇒ "x" ⇒ "*" ⇒ Ⓑ ⇒ "done" ⇒ Ⓒ
-		//                 ⇙ ⇖
-		//                 int
+		// Ⓐ ⇒ "x*" ⇒ "*" ⇒ Ⓑ ⇒ "done" ⇒ Ⓒ
+		//   ⇘ ⇒  "y*" ⇒ ⇗  ⇙ ⇖
+		//                  int
 		//
-		machine.transit().from(A).via("x", "shortcut").to(C);
+		machine.transit().from(A).via("re: x.*", "shortcut").to(C);
 		machine.transit().from(B).via("#").to(B);
 		machine.transit().from(B).via("done").to(C);
-		machine.transit().from(A).via("x", "*", "y").to(B);
+		machine.transit().from(A).via("re: x.*", "*", "y").to(B);
+		machine.transit().from(A).via("re: y.*").to(B);
 	}
 
 	@Test
@@ -45,6 +46,9 @@ public class StateMachineTest extends Assert {
 	private Tracker<S> performSimpleMoves() {
 		Tracker<S> tracker = machine.tracker(A);
 		checkState(tracker, A);
+		checkMove(tracker, "yellow", B);
+		checkPath(tracker, "yellow");
+		checkReset(tracker, A);
 		checkMove(tracker, "x", null);
 		checkPath(tracker, "x");
 		checkMove(tracker, "hello", null);
@@ -160,6 +164,12 @@ public class StateMachineTest extends Assert {
 
 	private void checkPath(Tracker<S> tracker, Object... expectedPath) {
 		assertEquals(Arrays.asList(expectedPath), tracker.getPath());
+	}
+
+	private void checkReset(Tracker<S> tracker, S value) {
+		tracker.reset(value);
+		checkState(tracker, value);
+		checkPath(tracker);
 	}
 
 	public static enum S {

--- a/kaizen-openapi-normalizer/src/test/java/com/reprezen/kaizen/normalizer/test/StateMachineTest.java
+++ b/kaizen-openapi-normalizer/src/test/java/com/reprezen/kaizen/normalizer/test/StateMachineTest.java
@@ -31,10 +31,10 @@ public class StateMachineTest extends Assert {
 		//                 ⇙ ⇖
 		//                 int
 		//
-		machine.transit().from(A).via("x", "*", "y").to(B);
 		machine.transit().from(A).via("x", "shortcut").to(C);
 		machine.transit().from(B).via("#").to(B);
 		machine.transit().from(B).via("done").to(C);
+		machine.transit().from(A).via("x", "*", "y").to(B);
 	}
 
 	@Test

--- a/kaizen-openapi-normalizer/src/test/resources/models/StateWalkV3.yaml
+++ b/kaizen-openapi-normalizer/src/test/resources/models/StateWalkV3.yaml
@@ -8,6 +8,7 @@ info:
 servers:
   - url: https://api.beamup.com/v1
 paths:
+  x-extension: Caught you! Fix the state machine NOW.
   /products:
     get:
       summary: Product Types


### PR DESCRIPTION
Extended state machine transit semantics to include regex-based edges, so e.g. transits to PATH state can be via `paths` -> `/.*` and not `paths`-> _anything_ as before. This prevents, e.g. vendor extentions on the Paths Object from being misinterpreted as path items.